### PR TITLE
Remove the JsonSerializerOptions in favor of a single JsonIgnore

### DIFF
--- a/Models/WikiEntry.cs
+++ b/Models/WikiEntry.cs
@@ -19,6 +19,7 @@ namespace wikiAPI.Models
         public int WikiCategoryID { get; set; }
 
         // For reference in code
+        [JsonIgnore]
         public WikiCategory? WikiCategory { get; set; }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -8,9 +8,6 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add controllers, ignore recursive calls, and don't automatically try to validate
 builder.Services.AddControllers()
-.AddJsonOptions(options =>
-    options.JsonSerializerOptions.ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles
-)
 .ConfigureApiBehaviorOptions(options =>
 {
     options.SuppressModelStateInvalidFilter = true;


### PR DESCRIPTION
The circular dependency only happens in one instance, when category data if requested from an entry, and vice versa.
A single JsonIgnore can fix this in WikiEntry.cs